### PR TITLE
Add manual start

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,9 @@ NOTE: On Linux you need to install inotify-tools.
           [ {:exsync, "~> 0.1", only: :dev} ]
         end
 
-3. List `:exsync` as your application dependencies:
+3. Start your application the usual way, e.g., `iex -S mix`, then:
 
-        def application do
-          [ applications: [:exsync] ]
-        end
+        ExSync.start()
 
 ## Usage for umbrella project
 

--- a/lib/exsync.ex
+++ b/lib/exsync.ex
@@ -10,4 +10,8 @@ defmodule ExSync do
     end
     {:ok, self}
   end
+
+  def start() do
+    Application.ensure_all_started(:exsync)
+  end
 end


### PR DESCRIPTION
This way you don't need to add `ExSync` to `applications`. This means it's not automatically started when you start the client application, but that's fine since using `ExSync` means you don't need to restart your own project nearly as much. Also, that's the way [sync](https://github.com/rustyio/sync recommends) for their similar Erlang library and I've been using it that way -- it somehow feels nice to control turning it on explicitly. Finally, this keeps `ExSync` from being added to a release.