### PR TITLE
Update 'alternative' start info

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ ExSync deps on [FileSystem](https://github.com/falood/file_system)
             import Supervisor.Spec, warn: false
 
             case Code.ensure_loaded(ExSync) do
-              {:module, ExSync} ->
-                ExSync.start()
+              {:module, ExSync = mod} ->
+                mod.start()
               {:error, :nofile} ->
                 :ok
             end


### PR DESCRIPTION
This update to the alternative start instructions avoids a compiler warning when building the project if the module is not availabe -- such as when the mix environment is not "dev".