### PR TITLE
Make src monitoring optional, defaulted on.

### DIFF
--- a/lib/exsync.ex
+++ b/lib/exsync.ex
@@ -4,9 +4,12 @@ defmodule ExSync do
   def start(_, _) do
     case Mix.env do
       :dev ->
-        ExSync.SrcMonitor.start_link()
+        if ExSync.Config.src_monitor_enabled do
+          ExSync.SrcMonitor.start_link()
+          Logger.info "ExSync source monitor started."
+        end
         ExSync.BeamMonitor.start_link()
-        Logger.info "ExSync started."
+        Logger.info "ExSync beam monitor started."
       _ ->
         Logger.error "ExSync NOT started. Only `:dev` environment is supported."
     end

--- a/lib/exsync/config.ex
+++ b/lib/exsync/config.ex
@@ -1,3 +1,5 @@
+require Logger
+
 defmodule ExSync.Config do
   def beam_dirs do
     if Mix.Project.umbrella? do
@@ -11,6 +13,19 @@ defmodule ExSync.Config do
     else
       [Mix.Project.compile_path]
     end |> List.flatten
+  end
+
+  def src_monitor_enabled do
+    case Application.fetch_env(application(), :src_monitor) do
+      :error ->
+        Logger.debug("Defaulting to enable source monitor, set config :exsync, src_monitor: false to disable")
+        true
+      {:ok, value} when value in [true, false] ->
+        value
+      {:ok, invalid} ->
+        Logger.error("Value #{inspect invalid} not valid for setting :src_monitor, expected true or false.  Enabling source monitor.")
+        true
+    end
   end
 
   def src_dirs do


### PR DESCRIPTION
This allows for better compatibility with integrated editor tooling
that recompiles project files on save. This will let the external recompiled
beams get picked up, without triggering any additional compilation in app. 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

Default behavior:

![exsync-default](https://user-images.githubusercontent.com/1130204/31897518-9db4bd24-b7e4-11e7-87a6-115b0fd02b0a.png)

When the `:src_monitor`  option is provided and `false`:

![exsync-no-src](https://user-images.githubusercontent.com/1130204/31897709-3a9b8a32-b7e5-11e7-830b-e8d3bae3610e.png)

When the `:src_monitor`  option is provided and `true`:
![Uploading exsync-yes-src.png…]()


When an invalid src_monitor value is given: 

![exsync](https://user-images.githubusercontent.com/1130204/31897426-575b6dd2-b7e4-11e7-9143-e8b136554b95.png)