### PR TITLE
Experimental: refine fs events to prevent spurious recompile/loads

### DIFF
--- a/lib/exsync/beam_monitor.ex
+++ b/lib/exsync/beam_monitor.ex
@@ -17,8 +17,14 @@ defmodule ExSync.BeamMonitor do
       |> case do
         # update
         {_, _, true, true} ->
-          Logger.info("reload module #{Path.basename(path, ".beam")}")
-          ExSync.Utils.reload(path)
+          # At least on linux platform, we're seeing a :modified event followed by a
+          # :modified, closed event.  By ensuring the modified event arrives on its own,
+          # we should be ablle to ensure we reload only once in a cross-platorm friendly way.
+          # Note: TODO I don't have a Mac or Windows env to verify this!
+          if [:modified] == events do
+            Logger.info "reload module #{Path.basename(path, ".beam")}"
+            ExSync.Utils.reload path
+          end
 
         # temp file
         {true, true, _, false} ->

--- a/lib/exsync/src_monitor.ex
+++ b/lib/exsync/src_monitor.ex
@@ -21,7 +21,17 @@ defmodule ExSync.SrcMonitor do
         %{watcher_pid: watcher_pid} = state
       ) do
     if Path.extname(path) in ExSync.Config.src_extensions() do
-      ExSync.Utils.recomplete()
+      # This may also vary based on editor - when saving a file in neovim on linux,
+      # events received ar3e:
+      #   :modified
+      #   :modified, :closed
+      #   :attribute
+      # Rather than coding specific behaviors for each OS, look for the modified event in
+      # isolation to trigger things.
+      # TODO: untested assumption that this behavior is common across Mac/Linux/Win
+      if [:modified] == events do
+        ExSync.Utils.recomplete()
+      end
     end
 
     {:noreply, state}

--- a/lib/exsync/src_monitor.ex
+++ b/lib/exsync/src_monitor.ex
@@ -17,7 +17,7 @@ defmodule ExSync.SrcMonitor do
   end
 
   def handle_info(
-        {:file_event, watcher_pid, {path, _events}},
+        {:file_event, watcher_pid, {path, events}},
         %{watcher_pid: watcher_pid} = state
       ) do
     if Path.extname(path) in ExSync.Config.src_extensions() do


### PR DESCRIPTION
Rebase https://github.com/falood/exsync/pull/13 so that it applies cleanly. Left the comments intact. Tested on Arch Linux