### PR TITLE
Optionally call a callback when finished reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ def deps do
 end
 ```
 
-3. Start your application the usual way, e.g., `iex -S mix`, then:
+3. (If runing Elixir < 1.4) Start your application the usual way, e.g., `iex -S mix`, then:
 
 ```elixir
 ExSync.start()

--- a/lib/exsync/beam_monitor.ex
+++ b/lib/exsync/beam_monitor.ex
@@ -1,17 +1,24 @@
 require Logger
 
 defmodule ExSync.BeamMonitor do
-  def start_link do
-    GenServer.start_link(__MODULE__, [])
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts)
   end
 
-  def init([]) do
+  def init(opts) when is_list(opts) do
     {:ok, watcher_pid} = FileSystem.start_link(dirs: ExSync.Config.beam_dirs())
     FileSystem.subscribe(watcher_pid)
-    {:ok, %{watcher_pid: watcher_pid}}
+
+    {:ok, %{watcher_pid: watcher_pid, finished_reloading_timer: false}}
   end
 
-  def handle_info({:file_event, watcher_pid, {path, events}}, %{watcher_pid: watcher_pid} = state) do
+  def handle_info({:file_event, watcher_pid, {path, events}}, state) do
+    %{watcher_pid: watcher_pid, finished_reloading_timer: finished_reloading_timer} = state
+
+    if finished_reloading_timer do
+      Process.cancel_timer(finished_reloading_timer)
+    end
+
     if Path.extname(path) in [".beam"] do
       {:created in events, :removed in events, :modified in events, File.exists?(path)}
       |> case do
@@ -35,11 +42,24 @@ defmodule ExSync.BeamMonitor do
       end
     end
 
-    {:noreply, state}
+    reload_timeout = ExSync.Config.reload_timeout()
+    timer_ref = Process.send_after(self(), :reload_complete, reload_timeout)
+
+    {:noreply, %{state | finished_reloading_timer: timer_ref}}
   end
 
   def handle_info({:file_event, watcher_pid, :stop}, %{watcher_pid: watcher_pid} = state) do
     Logger.info("ExSync beam monitor stopped.")
+    {:noreply, state}
+  end
+
+  def handle_info(:reload_complete, state) do
+    Logger.info("ExSync reload complete!")
+    if callback = ExSync.Config.reload_callback() do
+      {mod, fun, args} = callback
+      Task.start(mod, fun, args)
+    end
+
     {:noreply, state}
   end
 end


### PR DESCRIPTION
To use set `:reload_callback` to an MFA in your application configuration. You can also optionally set the `:reload_timeout` to configure how long exsync waits before deciding that we are done recompiling.

Example:

```
config :exsync,
  reload_timeout: 75,
  reload_callback: {GenServer, :call, [Play.Component.Nav, :reload_current_scene]}
```

This is useful if you want to trigger something on your application such as a page refresh. The example I have here reloads the current scenic scene.

Is this something that you're interested in merging? If so then I will add appropriate documentation.