### PR TITLE
General improvements

### DIFF
--- a/lib/exsync/beam_monitor.ex
+++ b/lib/exsync/beam_monitor.ex
@@ -29,8 +29,8 @@ defmodule ExSync.BeamMonitor do
           # we should be ablle to ensure we reload only once in a cross-platorm friendly way.
           # Note: TODO I don't have a Mac or Windows env to verify this!
           if [:modified] == events do
-            Logger.info "reload module #{Path.basename(path, ".beam")}"
-            ExSync.Utils.reload path
+            Logger.info("reload module #{Path.basename(path, ".beam")}")
+            ExSync.Utils.reload(path)
           end
 
         # temp file
@@ -61,6 +61,7 @@ defmodule ExSync.BeamMonitor do
 
   def handle_info(:reload_complete, state) do
     Logger.info("ExSync reload complete!")
+
     if callback = ExSync.Config.reload_callback() do
       {mod, fun, args} = callback
       Task.start(mod, fun, args)

--- a/lib/exsync/config.ex
+++ b/lib/exsync/config.ex
@@ -66,14 +66,14 @@ defmodule ExSync.Config do
   defp src_default_dirs do
     if Mix.Project.umbrella?() do
       for %Mix.Dep{app: app, opts: opts} <- Mix.Dep.Umbrella.loaded() do
-        Mix.Project.in_project(app, opts[:path], fn _ -> src_default_dirs() end)
+        Mix.Project.in_project(app, opts[:dest], fn _ -> src_default_dirs() end)
       end
     else
       dep_paths =
         Mix.Dep.cached()
-        |> Enum.filter(fn dep -> dep.opts[:path] != nil end)
+        |> Enum.filter(fn dep -> dep.opts[:dest] != nil end)
         |> Enum.map(fn %Mix.Dep{app: app, opts: opts} ->
-          Mix.Project.in_project(app, opts[:path], fn _ -> src_default_dirs() end)
+          Mix.Project.in_project(app, opts[:dest], fn _ -> src_default_dirs() end)
         end)
 
       self_paths =

--- a/lib/exsync/src_monitor.ex
+++ b/lib/exsync/src_monitor.ex
@@ -16,8 +16,8 @@ defmodule ExSync.SrcMonitor do
     {:ok, %{watcher_pid: watcher_pid}}
   end
 
-  def handle_info({:file_event, watcher_pid, {path, events}}, %{watcher_pid: watcher_pid}=state) do
-    if Path.extname(path) in ExSync.Config.src_extensions do
+  def handle_info({:file_event, watcher_pid, {path, events}}, %{watcher_pid: watcher_pid} = state) do
+    if Path.extname(path) in ExSync.Config.src_extensions() do
       # This may also vary based on editor - when saving a file in neovim on linux,
       # events received ar3e:
       #   :modified
@@ -26,8 +26,8 @@ defmodule ExSync.SrcMonitor do
       # Rather than coding specific behaviors for each OS, look for the modified event in
       # isolation to trigger things.
       # TODO: untested assumption that this behavior is common across Mac/Linux/Win
-      if [:modified] == events do
-        ExSync.Utils.recomplete
+      if :modified in events do
+        ExSync.Utils.recomplete()
       end
     end
 

--- a/lib/exsync/utils.ex
+++ b/lib/exsync/utils.ex
@@ -1,6 +1,10 @@
+require Logger
+
 defmodule ExSync.Utils do
   def recomplete do
-    System.cmd("mix", ["compile"], cd: ExSync.Config.app_source_dir())
+    "mix"
+    |> System.cmd(["compile"], cd: ExSync.Config.app_source_dir())
+    |> log_compile_cmd()
   end
 
   def unload(module) when is_atom(module) do
@@ -19,4 +23,11 @@ defmodule ExSync.Utils do
     module = beam_path |> Path.basename(".beam") |> String.to_atom()
     :code.load_binary(module, file, binary)
   end
+
+  defp log_compile_cmd({out, status} = result) when is_bitstring(out) and status > 0 do
+    out |> Logger.info()
+    result
+  end
+
+  defp log_compile_cmd(result), do: result
 end


### PR DESCRIPTION
#### mix format

#### log compile errors
Log system cmd result in case of errors (status > 0). Probably fixes #14

#### fix path resolution
Changed from `path` to `dest` to get full path.

#### fix events detection
Sometimes it returns more than one event at the same, which was causing the `==` operator to fail.