### PR TITLE
Fix detection on Mac OS X

### DIFF
--- a/lib/exsync/beam_monitor.ex
+++ b/lib/exsync/beam_monitor.ex
@@ -28,7 +28,7 @@ defmodule ExSync.BeamMonitor do
           # :modified, closed event.  By ensuring the modified event arrives on its own,
           # we should be ablle to ensure we reload only once in a cross-platorm friendly way.
           # Note: TODO I don't have a Mac or Windows env to verify this!
-          if [:modified] == events do
+          if :modified in events do
             Logger.info "reload module #{Path.basename(path, ".beam")}"
             ExSync.Utils.reload path
           end

--- a/lib/exsync/src_monitor.ex
+++ b/lib/exsync/src_monitor.ex
@@ -26,7 +26,7 @@ defmodule ExSync.SrcMonitor do
       # Rather than coding specific behaviors for each OS, look for the modified event in
       # isolation to trigger things.
       # TODO: untested assumption that this behavior is common across Mac/Linux/Win
-      if [:modified] == events do
+      if :modified in events do
         ExSync.Utils.recomplete
       end
     end


### PR DESCRIPTION
On Mac OS X the events are detected multiple at a time which causes the `[:modified] == events` check to fail. The regression was introduce in #13 