### PR TITLE
Fix multi-level path deps

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "file_system": {:hex, :file_system, "0.2.2", "7f1e9de4746f4eb8a4ca8f2fbab582d84a4e40fa394cce7bfcb068b988625b06", [:mix], [], "hexpm"},
+  "file_system": {:hex, :file_system, "0.2.7", "e6f7f155970975789f26e77b8b8d8ab084c59844d8ecfaf58cbda31c494d14aa", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
If the top-level app has a path-based dependency (A), and that dependency also has a path-based dependency (B) exsync would fail to start because it tried to use the relative path from dependency B from its own working directory which failed because the path to B is relative to A's directory.

So this commit uses `Path.expand/2` to get the correct path to the dependency.