### PR TITLE
Drop support for Elixir < 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Breaking Changes
+
+* Increase minimum supported Elixir version from 1.3 to 1.4
+
 ## [0.2.4] - 2019-07-22
 
 * Recursively watch all local path dependencies [#27](https://github.com/falood/exsync/pull/27)

--- a/README.md
+++ b/README.md
@@ -21,33 +21,6 @@ def deps do
 end
 ```
 
-3. (If runing Elixir < 1.4) Start your application the usual way, e.g., `iex -S mix`, then:
-
-```elixir
-ExSync.start()
-```
-
-4. (Alternative) To always start ExSync when available, add the following to an application's `start/2`:
-
-```elixir
-defmodule MyApp do
-  use Application
-
-  def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
-    case Code.ensure_loaded(ExSync) do
-      {:module, ExSync = mod} ->
-        mod.start()
-      {:error, :nofile} ->
-        :ok
-    end
-
-    # ... rest of your applications start script.
-  end
-end
-```
-
 ## Usage for umbrella project
 
 1. Create an umbrella project

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExSync.Mixfile do
     [
       app: :exsync,
       version: "0.2.4",
-      elixir: "~> 1.3",
+      elixir: "~> 1.4",
       elixirc_paths: ["lib", "web"],
       deps: deps(),
       description: "Yet another Elixir reloader.",
@@ -19,7 +19,10 @@ defmodule ExSync.Mixfile do
   end
 
   def application do
-    [mod: {ExSync, []}, applications: [:logger]]
+    [
+      mod: {ExSync, []},
+      extra_applications: [:logger]
+    ]
   end
 
   defp deps do


### PR DESCRIPTION
Elixir 1.4 was released about 2.5 years ago. Remove it to clean up and modernize the code (also helps with the instructions)

* Move to use `extra_applications`
* Remove < 1.4 instructions from Readme