### PR TITLE
Make ExSync logging configurable and dont overwrite IEx prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+* Make logging configurable and make logging (optionally) not overwrite the IEx prompt [#32](https://github.com/falood/exsync/pull/32)
+
 ### Breaking Changes
 
 * Increase minimum supported Elixir version from 1.3 to 1.4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ def deps do
 end
 ```
 
+Optionally add this snippet to your `.iex.exs` (in the root of your project) or your `~/.iex.exs`:
+```
+if Code.ensure_loaded?(ExSync) && function_exported?(ExSync, :register_group_leader, 0) do
+  ExSync.register_group_leader()
+end
+```
+
+This will prevent the ExSync logs from overwriting your IEx prompt.
+Alternatively you can always just run `ExSync.register_group_leader()` in your
+IEx prompt.
+
 ## Usage for umbrella project
 
 1. Create an umbrella project
@@ -66,6 +77,8 @@ For example, to watch `.js` and `.css` files add this to your `config.exs`:
 ```elixir
 config :exsync, extra_extensions: [".js", ".css"]
 ```
+
+`:logging_enabled` - Set to false to disable logging (default true)
 
 `:reload_callback` - A callback [MFA](https://codereviewvideos.com/blog/what-is-mfa-in-elixir/) that is called when a set of files are done reloading. Can be used to implement your own special handling to react to file reloads.
 

--- a/lib/exsync.ex
+++ b/lib/exsync.ex
@@ -4,6 +4,8 @@ defmodule ExSync do
   def start(_, _) do
     case Mix.env() do
       :dev ->
+        ExSync.Logger.Server.start_link()
+
         if ExSync.Config.src_monitor_enabled() do
           ExSync.SrcMonitor.start_link()
           Logger.debug("ExSync source monitor started.")
@@ -22,4 +24,6 @@ defmodule ExSync do
   def start() do
     Application.ensure_all_started(:exsync)
   end
+
+  defdelegate register_group_leader, to: ExSync.Logger.Server
 end

--- a/lib/exsync.ex
+++ b/lib/exsync.ex
@@ -8,11 +8,17 @@ defmodule ExSync do
 
         if ExSync.Config.src_monitor_enabled() do
           ExSync.SrcMonitor.start_link()
-          Logger.debug("ExSync source monitor started.")
+
+          if ExSync.Config.logging_enabled() do
+            Logger.debug("ExSync source monitor started.")
+          end
         end
 
         ExSync.BeamMonitor.start_link()
-        Logger.debug("ExSync beam monitor started.")
+
+        if ExSync.Config.logging_enabled() do
+          Logger.debug("ExSync beam monitor started.")
+        end
 
       _ ->
         Logger.error("ExSync NOT started. Only `:dev` environment is supported.")

--- a/lib/exsync/beam_monitor.ex
+++ b/lib/exsync/beam_monitor.ex
@@ -29,7 +29,8 @@ defmodule ExSync.BeamMonitor do
           # we should be ablle to ensure we reload only once in a cross-platorm friendly way.
           # Note: TODO I don't have a Mac or Windows env to verify this!
           if :modified in events do
-            Logger.debug("reload module #{Path.basename(path, ".beam")}")
+            ExSync.Logger.log("reload module #{Path.basename(path, ".beam")}")
+
             ExSync.Utils.reload(path)
           end
 
@@ -39,7 +40,7 @@ defmodule ExSync.BeamMonitor do
 
         # remove
         {_, true, _, false} ->
-          Logger.debug("unload module #{Path.basename(path, ".beam")}")
+          ExSync.Logger.log("unload module #{Path.basename(path, ".beam")}")
           ExSync.Utils.unload(path)
 
         # create
@@ -55,12 +56,12 @@ defmodule ExSync.BeamMonitor do
   end
 
   def handle_info({:file_event, watcher_pid, :stop}, %{watcher_pid: watcher_pid} = state) do
-    Logger.debug("ExSync beam monitor stopped.")
+    ExSync.Logger.log("beam monitor stopped")
     {:noreply, state}
   end
 
   def handle_info(:reload_complete, state) do
-    Logger.debug("ExSync reload complete!")
+    ExSync.Logger.log("reload complete")
 
     if callback = ExSync.Config.reload_callback() do
       {mod, fun, args} = callback

--- a/lib/exsync/config.ex
+++ b/lib/exsync/config.ex
@@ -5,6 +5,10 @@ defmodule ExSync.Config do
     Application.get_env(application(), :reload_timeout, 150)
   end
 
+  def logging_enabled do
+    Application.get_env(application(), :logging_enabled, true)
+  end
+
   def reload_callback do
     Application.get_env(application(), :reload_callback)
   end

--- a/lib/exsync/ex_logger.ex
+++ b/lib/exsync/ex_logger.ex
@@ -1,0 +1,4 @@
+defmodule ExSync.Logger do
+  alias ExSync.Logger.Server
+  defdelegate log(message), to: Server
+end

--- a/lib/exsync/logger/server.ex
+++ b/lib/exsync/logger/server.ex
@@ -1,0 +1,58 @@
+defmodule ExSync.Logger.Server do
+  @moduledoc """
+  Receives log messages from ExSync and sends them to the IEx group leader (if it exists)
+  """
+
+  use GenServer
+  require Logger
+
+  defmodule State do
+    defstruct group_leaders: MapSet.new()
+  end
+
+  def start_link(opts \\ []) do
+    {:ok, GenServer.start_link(__MODULE__, opts, name: __MODULE__)}
+  end
+
+  @doc """
+  Should be called from IEx
+  """
+  def register_group_leader do
+    if IEx.started?() do
+      group_leader = Process.info(self())[:group_leader]
+      GenServer.call(__MODULE__, {:register_group_leader, group_leader})
+    end
+  end
+
+  def log(message) do
+    GenServer.call(__MODULE__, {:log, message})
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    {:ok, %State{}}
+  end
+
+  @impl GenServer
+  def handle_call({:log, message}, _from, state) do
+    maybe_log(message, state.group_leaders)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:register_group_leader, pid}, _from, state) do
+    {:reply, :ok, %State{state | group_leaders: MapSet.put(state.group_leaders, pid)}}
+  end
+
+  defp maybe_log(message, group_leaders) do
+    if ExSync.Config.logging_enabled() do
+      message = color_message(["[exsync] ", message])
+
+      MapSet.to_list(group_leaders)
+      |> Enum.each(&IO.puts(&1, message))
+    end
+  end
+
+  defp color_message(message) do
+    [IO.ANSI.format_fragment(:cyan, true), message | IO.ANSI.reset()]
+  end
+end


### PR DESCRIPTION
By sending messages directly to the group leader of the IEx process it is possible to not overwrite the user's IEx prompt which is very helpful when developing. Also make it possible to disable the logging completely.

Fixes #24 