### PR TITLE
Create supervision tree and show compilation warnings nicely

### DIFF
--- a/lib/exsync.ex
+++ b/lib/exsync.ex
@@ -1,35 +1,5 @@
 require Logger
 
 defmodule ExSync do
-  def start(_, _) do
-    case Mix.env() do
-      :dev ->
-        ExSync.Logger.Server.start_link()
-
-        if ExSync.Config.src_monitor_enabled() do
-          ExSync.SrcMonitor.start_link()
-
-          if ExSync.Config.logging_enabled() do
-            Logger.debug("ExSync source monitor started.")
-          end
-        end
-
-        ExSync.BeamMonitor.start_link()
-
-        if ExSync.Config.logging_enabled() do
-          Logger.debug("ExSync beam monitor started.")
-        end
-
-      _ ->
-        Logger.error("ExSync NOT started. Only `:dev` environment is supported.")
-    end
-
-    {:ok, self()}
-  end
-
-  def start() do
-    Application.ensure_all_started(:exsync)
-  end
-
   defdelegate register_group_leader, to: ExSync.Logger.Server
 end

--- a/lib/exsync/application.ex
+++ b/lib/exsync/application.ex
@@ -1,0 +1,47 @@
+require Logger
+
+defmodule ExSync.Application do
+  def start(_, _) do
+    case Mix.env() do
+      :dev ->
+        start_supervisor()
+
+      _ ->
+        Logger.error("ExSync NOT started. Only `:dev` environment is supported.")
+        {:ok, self()}
+    end
+  end
+
+  def start() do
+    Application.ensure_all_started(:exsync)
+  end
+
+  def start_supervisor do
+    children =
+      [
+        ExSync.Logger.Server,
+        maybe_include_src_monitor(),
+        ExSync.BeamMonitor
+      ]
+      |> List.flatten()
+
+    opts = [
+      strategy: :one_for_one,
+      max_restarts: 2,
+      max_seconds: 3,
+      name: ExSync.Supervisor
+    ]
+
+    Supervisor.start_link(children, opts)
+  end
+
+  def maybe_include_src_monitor do
+    if ExSync.Config.src_monitor_enabled() do
+      [ExSync.SrcMonitor]
+    else
+      []
+    end
+  end
+
+  defdelegate register_group_leader, to: ExSync.Logger.Server
+end

--- a/lib/exsync/logger.ex
+++ b/lib/exsync/logger.ex
@@ -1,5 +1,8 @@
 defmodule ExSync.Logger do
   alias ExSync.Logger.Server
+
   defdelegate debug(message), to: Server
+  defdelegate info(message), to: Server
+  defdelegate warn(message), to: Server
   defdelegate error(message), to: Server
 end

--- a/lib/exsync/logger/server.ex
+++ b/lib/exsync/logger/server.ex
@@ -11,7 +11,7 @@ defmodule ExSync.Logger.Server do
   end
 
   def start_link(opts \\ []) do
-    {:ok, GenServer.start_link(__MODULE__, opts, name: __MODULE__)}
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
   @doc """
@@ -25,6 +25,8 @@ defmodule ExSync.Logger.Server do
   end
 
   def debug(message), do: log(:debug, message)
+  def info(message), do: log(:info, message)
+  def warn(message), do: log(:warn, message)
   def error(message), do: log(:error, message)
 
   def log(level, message) do
@@ -51,7 +53,7 @@ defmodule ExSync.Logger.Server do
       message = color_message(["[exsync] ", message], level)
 
       MapSet.to_list(group_leaders)
-      |> Enum.each(&IO.puts(&1, message))
+      |> Enum.each(&IO.binwrite(&1, message))
     end
   end
 
@@ -61,5 +63,7 @@ defmodule ExSync.Logger.Server do
   end
 
   defp color(:debug), do: :cyan
+  defp color(:info), do: :normal
+  defp color(:warn), do: :yellow
   defp color(:error), do: :red
 end

--- a/lib/exsync/utils.ex
+++ b/lib/exsync/utils.ex
@@ -1,6 +1,6 @@
 defmodule ExSync.Utils do
   def recomplete do
-    ExSync.Logger.debug("running mix compile")
+    ExSync.Logger.debug("running mix compile\n")
 
     System.cmd("mix", ["compile"], cd: ExSync.Config.app_source_dir())
     |> log_compile_cmd()
@@ -24,9 +24,21 @@ defmodule ExSync.Utils do
   end
 
   defp log_compile_cmd({output, status} = result) when is_binary(output) and status > 0 do
-    ExSync.Logger.error(["error while compiling\n", output])
+    ExSync.Logger.error(["error while compiling\n", output, "\n"])
     result
   end
 
-  defp log_compile_cmd(result), do: result
+  defp log_compile_cmd({"", _status} = result), do: result
+
+  defp log_compile_cmd({output, _status} = result) when is_binary(output) do
+    message = ["compiling\n", output]
+
+    if String.contains?(output, "warning:") do
+      ExSync.Logger.warn(message)
+    else
+      ExSync.Logger.debug(message)
+    end
+
+    result
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule ExSync.Mixfile do
 
   def application do
     [
-      mod: {ExSync, []},
+      mod: {ExSync.Application, []},
       extra_applications: [:logger]
     ]
   end


### PR DESCRIPTION
Also update logging to have more levels and not auto-append newlines

Before:
![exsync-warnings-before-screenshot](https://user-images.githubusercontent.com/9973/82080894-1c6bdd00-9681-11ea-9562-5cb9b01f1694.png)

After:
![exsync-warnings-after-screenshot](https://user-images.githubusercontent.com/9973/82080907-2097fa80-9681-11ea-9550-8d806f50ae7e.png)

Note: In these screenshots the need to address #34 is very obvious

~Based on #33 and #32~