### PR TITLE
Throttle recompilation

### DIFF
--- a/lib/exsync/beam_monitor.ex
+++ b/lib/exsync/beam_monitor.ex
@@ -45,10 +45,6 @@ defmodule ExSync.BeamMonitor do
 
     action = action(Path.extname(path), path, events)
 
-    # ExSync.Logger.debug("#{inspect action} changes to #{inspect path}\n")
-    # TODO: Passing a list to debug appears to be broken
-    # ExSync.Logger.debug([inspect(action), " changes to ", inspect(path), "\n"])
-
     state =
       track_module_change(action, path, state)
       # TODO: Is this correct?
@@ -84,9 +80,6 @@ defmodule ExSync.BeamMonitor do
   end
 
   defp action(".beam", path, events) do
-    # At least on linux platform, we're seeing a :modified event followed by a
-    # :modified, closed event.  By ensuring the modified event arrives on its own,
-    # we should be ablle to ensure we reload only once in a cross-platorm friendly way.
     case {:created in events, :removed in events, :modified in events, File.exists?(path)} do
       # update
       {_, _, true, true} -> :reload_module

--- a/lib/exsync/beam_monitor.ex
+++ b/lib/exsync/beam_monitor.ex
@@ -1,6 +1,19 @@
 defmodule ExSync.BeamMonitor do
   use GenServer
 
+  @throttle_timeout_ms 100
+
+  defmodule State do
+    @enforce_keys [
+      :finished_reloading_timer,
+      :throttle_timer,
+      :watcher_pid,
+      :unload_set,
+      :reload_set
+    ]
+    defstruct [:finished_reloading_timer, :throttle_timer, :watcher_pid, :unload_set, :reload_set]
+  end
+
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts)
   end
@@ -11,46 +24,35 @@ defmodule ExSync.BeamMonitor do
     FileSystem.subscribe(watcher_pid)
     ExSync.Logger.debug("ExSync beam monitor started.\n")
 
-    {:ok, %{watcher_pid: watcher_pid, finished_reloading_timer: false}}
+    state = %State{
+      finished_reloading_timer: false,
+      throttle_timer: nil,
+      watcher_pid: watcher_pid,
+      unload_set: MapSet.new(),
+      reload_set: MapSet.new()
+    }
+
+    {:ok, state}
   end
 
   @impl GenServer
   def handle_info({:file_event, _watcher_pid, {path, events}}, state) do
-    %{finished_reloading_timer: finished_reloading_timer} = state
+    %State{finished_reloading_timer: finished_reloading_timer} = state
 
     if finished_reloading_timer do
       Process.cancel_timer(finished_reloading_timer)
     end
 
-    if Path.extname(path) in [".beam"] do
-      {:created in events, :removed in events, :modified in events, File.exists?(path)}
-      |> case do
-        # update
-        {_, _, true, true} ->
-          # At least on linux platform, we're seeing a :modified event followed by a
-          # :modified, closed event.  By ensuring the modified event arrives on its own,
-          # we should be ablle to ensure we reload only once in a cross-platorm friendly way.
-          # Note: TODO I don't have a Mac or Windows env to verify this!
-          if :modified in events do
-            ExSync.Logger.debug("reload module #{Path.basename(path, ".beam")}\n")
+    action = action(Path.extname(path), path, events)
 
-            ExSync.Utils.reload(path)
-          end
+    # ExSync.Logger.debug("#{inspect action} changes to #{inspect path}\n")
+    # TODO: Passing a list to debug appears to be broken
+    # ExSync.Logger.debug([inspect(action), " changes to ", inspect(path), "\n"])
 
-        # temp file
-        {true, true, _, false} ->
-          nil
-
-        # remove
-        {_, true, _, false} ->
-          ExSync.Logger.debug("unload module #{Path.basename(path, ".beam")}\n")
-          ExSync.Utils.unload(path)
-
-        # create
-        _ ->
-          nil
-      end
-    end
+    state =
+      track_module_change(action, path, state)
+      # TODO: Is this correct?
+      |> maybe_update_throttle_timer()
 
     reload_timeout = ExSync.Config.reload_timeout()
     timer_ref = Process.send_after(self(), :reload_complete, reload_timeout)
@@ -63,6 +65,13 @@ defmodule ExSync.BeamMonitor do
     {:noreply, state}
   end
 
+  def handle_info(:throttle_timer_complete, state) do
+    state = reload_and_unload_modules(state)
+    state = %State{state | throttle_timer: nil}
+
+    {:noreply, state}
+  end
+
   def handle_info(:reload_complete, state) do
     ExSync.Logger.debug("reload complete\n")
 
@@ -72,5 +81,73 @@ defmodule ExSync.BeamMonitor do
     end
 
     {:noreply, state}
+  end
+
+  defp action(".beam", path, events) do
+    # At least on linux platform, we're seeing a :modified event followed by a
+    # :modified, closed event.  By ensuring the modified event arrives on its own,
+    # we should be ablle to ensure we reload only once in a cross-platorm friendly way.
+    case {:created in events, :removed in events, :modified in events, File.exists?(path)} do
+      # update
+      {_, _, true, true} -> :reload_module
+      # temp file
+      {true, true, _, false} -> :nothing
+      # remove
+      {_, true, _, false} -> :unload_module
+      # create and other
+      _ -> :nothing
+    end
+  end
+
+  defp action(_extname, _path, _events), do: :nothing
+
+  defp track_module_change(:nothing, _module, state), do: state
+
+  defp track_module_change(:reload_module, module, state) do
+    %State{reload_set: reload_set, unload_set: unload_set} = state
+
+    %State{
+      state
+      | reload_set: MapSet.put(reload_set, module),
+        unload_set: MapSet.delete(unload_set, module)
+    }
+  end
+
+  defp track_module_change(:unload_module, module, state) do
+    %State{reload_set: reload_set, unload_set: unload_set} = state
+
+    %State{
+      state
+      | reload_set: MapSet.delete(reload_set, module),
+        unload_set: MapSet.put(unload_set, module)
+    }
+  end
+
+  defp maybe_update_throttle_timer(%State{throttle_timer: nil} = state) do
+    %State{reload_set: reload_set, unload_set: unload_set} = state
+
+    if Enum.empty?(reload_set) && Enum.empty?(unload_set) do
+      state
+    else
+      # ExSync.Logger.debug("BeamMonitor Start throttle timer\n")
+      throttle_timer = Process.send_after(self(), :throttle_timer_complete, @throttle_timeout_ms)
+      %State{state | throttle_timer: throttle_timer}
+    end
+  end
+
+  defp maybe_update_throttle_timer(state), do: state
+
+  defp reload_and_unload_modules(%State{} = state) do
+    %State{reload_set: reload_set, unload_set: unload_set} = state
+
+    Enum.each(reload_set, fn module_path ->
+      ExSync.Utils.reload(module_path)
+    end)
+
+    Enum.each(unload_set, fn module_path ->
+      ExSync.Utils.unload(module_path)
+    end)
+
+    %State{state | reload_set: MapSet.new(), unload_set: MapSet.new()}
   end
 end

--- a/lib/exsync/src_monitor.ex
+++ b/lib/exsync/src_monitor.ex
@@ -1,6 +1,12 @@
 defmodule ExSync.SrcMonitor do
   use GenServer
 
+  @throttle_timeout_ms 100
+
+  defmodule State do
+    defstruct [:throttle_timer, :file_events, :watcher_pid]
+  end
+
   def start_link(_opts \\ []) do
     GenServer.start_link(__MODULE__, [])
   end
@@ -15,24 +21,28 @@ defmodule ExSync.SrcMonitor do
 
     FileSystem.subscribe(watcher_pid)
     ExSync.Logger.debug("ExSync source monitor started.\n")
-    {:ok, %{watcher_pid: watcher_pid}}
+    {:ok, %State{watcher_pid: watcher_pid}}
   end
 
   @impl GenServer
   def handle_info({:file_event, watcher_pid, {path, events}}, %{watcher_pid: watcher_pid} = state) do
-    if Path.extname(path) in ExSync.Config.src_extensions() do
-      # This may also vary based on editor - when saving a file in neovim on linux,
-      # events received ar3e:
-      #   :modified
-      #   :modified, :closed
-      #   :attribute
-      # Rather than coding specific behaviors for each OS, look for the modified event in
-      # isolation to trigger things.
-      # TODO: untested assumption that this behavior is common across Mac/Linux/Win
-      if :modified in events do
-        ExSync.Utils.recomplete()
+    matching_extension? = Path.extname(path) in ExSync.Config.src_extensions()
+
+    # This varies based on editor and OS - when saving a file in neovim on linux,
+    # events received are:
+    #   :modified
+    #   :modified, :closed
+    #   :attribute
+    # Rather than coding specific behaviors for each OS, look for the modified event in
+    # isolation to trigger things.
+    matching_event? = :modified in events
+
+    state =
+      if matching_extension? && matching_event? do
+        maybe_recomplete(state)
+      else
+        state
       end
-    end
 
     {:noreply, state}
   end
@@ -41,4 +51,17 @@ defmodule ExSync.SrcMonitor do
     ExSync.Logger.debug("ExSync src monitor stopped.\n")
     {:noreply, state}
   end
+
+  def handle_info(:throttle_timer_complete, state) do
+    ExSync.Utils.recomplete()
+    state = %State{state | throttle_timer: nil}
+    {:noreply, state}
+  end
+
+  defp maybe_recomplete(%State{throttle_timer: nil} = state) do
+    throttle_timer = Process.send_after(self(), :throttle_timer_complete, @throttle_timeout_ms)
+    %State{state | throttle_timer: throttle_timer}
+  end
+
+  defp maybe_recomplete(%State{} = state), do: state
 end

--- a/lib/exsync/utils.ex
+++ b/lib/exsync/utils.ex
@@ -7,6 +7,7 @@ defmodule ExSync.Utils do
   end
 
   def unload(module) when is_atom(module) do
+    ExSync.Logger.debug("unload module #{inspect module}\n")
     module |> :code.purge()
     module |> :code.delete()
   end
@@ -17,6 +18,7 @@ defmodule ExSync.Utils do
 
   # beam file path
   def reload(beam_path) do
+    ExSync.Logger.debug("reload module #{Path.basename(beam_path, ".beam")}\n")
     file = beam_path |> to_charlist
     {:ok, binary, _} = :erl_prim_loader.get_file(file)
     module = beam_path |> Path.basename(".beam") |> String.to_atom()


### PR DESCRIPTION
Throttle in both the BeamMonitor and the SrcMonitor

This prevents `mix compile` from being run multiple times when it doesn't need to, along with a module being reloaded multiple times when it doesn't need to be (on some OS's such as Linux we receive `:modified` twice for one user-visible change to a file)

I plan to test this more locally before merging.

Fixes #34