### PR TITLE
Remove excess newlines from being emitted

### DIFF
--- a/lib/exsync/beam_monitor.ex
+++ b/lib/exsync/beam_monitor.ex
@@ -22,7 +22,7 @@ defmodule ExSync.BeamMonitor do
   def init(opts) when is_list(opts) do
     {:ok, watcher_pid} = FileSystem.start_link(dirs: ExSync.Config.beam_dirs())
     FileSystem.subscribe(watcher_pid)
-    ExSync.Logger.debug("ExSync beam monitor started.\n")
+    ExSync.Logger.debug("ExSync beam monitor started.")
 
     state = %State{
       finished_reloading_timer: false,
@@ -57,7 +57,7 @@ defmodule ExSync.BeamMonitor do
   end
 
   def handle_info({:file_event, watcher_pid, :stop}, %{watcher_pid: watcher_pid} = state) do
-    ExSync.Logger.debug("beam monitor stopped\n")
+    ExSync.Logger.debug("beam monitor stopped")
     {:noreply, state}
   end
 
@@ -69,7 +69,7 @@ defmodule ExSync.BeamMonitor do
   end
 
   def handle_info(:reload_complete, state) do
-    ExSync.Logger.debug("reload complete\n")
+    ExSync.Logger.debug("reload complete")
 
     if callback = ExSync.Config.reload_callback() do
       {mod, fun, args} = callback
@@ -122,7 +122,7 @@ defmodule ExSync.BeamMonitor do
     if Enum.empty?(reload_set) && Enum.empty?(unload_set) do
       state
     else
-      # ExSync.Logger.debug("BeamMonitor Start throttle timer\n")
+      # ExSync.Logger.debug("BeamMonitor Start throttle timer")
       throttle_timer = Process.send_after(self(), :throttle_timer_complete, @throttle_timeout_ms)
       %State{state | throttle_timer: throttle_timer}
     end

--- a/lib/exsync/logger/server.ex
+++ b/lib/exsync/logger/server.ex
@@ -53,7 +53,7 @@ defmodule ExSync.Logger.Server do
       if Enum.empty?(group_leaders) do
         Logger.log(level, message)
       else
-        message = color_message(["[exsync] ", message], level)
+        message = color_message(["[exsync] ", message, "\n"], level)
 
         MapSet.to_list(group_leaders)
         |> Enum.each(&IO.binwrite(&1, message))

--- a/lib/exsync/src_monitor.ex
+++ b/lib/exsync/src_monitor.ex
@@ -20,7 +20,7 @@ defmodule ExSync.SrcMonitor do
       )
 
     FileSystem.subscribe(watcher_pid)
-    ExSync.Logger.debug("ExSync source monitor started.\n")
+    ExSync.Logger.debug("ExSync source monitor started.")
     {:ok, %State{watcher_pid: watcher_pid}}
   end
 
@@ -48,7 +48,7 @@ defmodule ExSync.SrcMonitor do
   end
 
   def handle_info({:file_event, watcher_pid, :stop}, %{watcher_pid: watcher_pid} = state) do
-    ExSync.Logger.debug("ExSync src monitor stopped.\n")
+    ExSync.Logger.debug("ExSync src monitor stopped.")
     {:noreply, state}
   end
 

--- a/lib/exsync/utils.ex
+++ b/lib/exsync/utils.ex
@@ -1,13 +1,13 @@
 defmodule ExSync.Utils do
   def recomplete do
-    ExSync.Logger.debug("running mix compile\n")
+    ExSync.Logger.debug("running mix compile")
 
     System.cmd("mix", ["compile"], cd: ExSync.Config.app_source_dir(), stderr_to_stdout: true)
     |> log_compile_cmd()
   end
 
   def unload(module) when is_atom(module) do
-    ExSync.Logger.debug("unload module #{inspect module}\n")
+    ExSync.Logger.debug("unload module #{inspect module}")
     module |> :code.purge()
     module |> :code.delete()
   end
@@ -18,7 +18,7 @@ defmodule ExSync.Utils do
 
   # beam file path
   def reload(beam_path) do
-    ExSync.Logger.debug("reload module #{Path.basename(beam_path, ".beam")}\n")
+    ExSync.Logger.debug("reload module #{Path.basename(beam_path, ".beam")}")
     file = beam_path |> to_charlist
     {:ok, binary, _} = :erl_prim_loader.get_file(file)
     module = beam_path |> Path.basename(".beam") |> String.to_atom()
@@ -26,7 +26,7 @@ defmodule ExSync.Utils do
   end
 
   defp log_compile_cmd({output, status} = result) when is_binary(output) and status > 0 do
-    ExSync.Logger.error(["error while compiling\n", output, "\n"])
+    ExSync.Logger.error(["error while compiling\n", output])
     result
   end
 


### PR DESCRIPTION
Previously they were added primarily for use with `ExSync.register_group_leader/1` but that resulted in extra newlines when used with a typical logger configuration (which will have "\n" at the end of the logger format)