### PR TITLE
Support Elixir 1.15 and OTP 26

### DIFF
--- a/lib/exsync/config.ex
+++ b/lib/exsync/config.ex
@@ -38,7 +38,9 @@ defmodule ExSync.Config do
           Mix.Project.in_project(app, path, config, fn _ -> beam_dirs() end)
         end)
 
-      [Mix.Project.compile_path() | dep_paths]
+      # Elixir 1.15/OTP 26 compiles into the project build_path, but
+      # we append dep_paths to support earlier versions
+      [Mix.Project.build_path() | dep_paths]
     end
     |> List.flatten()
     |> Enum.uniq()

--- a/lib/exsync/logger/server.ex
+++ b/lib/exsync/logger/server.ex
@@ -26,7 +26,7 @@ defmodule ExSync.Logger.Server do
 
   def debug(message), do: log(:debug, message)
   def info(message), do: log(:info, message)
-  def warn(message), do: log(:warn, message)
+  def warn(message), do: log(:warning, message)
   def error(message), do: log(:error, message)
 
   def log(level, message) do


### PR DESCRIPTION
Watch entire `Mix.Project.build_path()` (i.e. `_build/dev` instead of `_build/dev/lib/inky_tester/ebin`) since Elixir 1.15/OTP 26 (I didn't verify which) builds path dependency's `.beam` files into the `_build` of the containing project instead of the `_build` of the dep (this change makes a lot of sense!)

Fixes https://github.com/falood/exsync/issues/53