### PR TITLE
Fix spdx identifier for license

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule ExSync.Mixfile do
   defp package do
     %{
       maintainers: ["Xiangrong Hao"],
-      licenses: ["BSD 3-Clause"],
+      licenses: ["BSD-3-Clause"],
       links: %{"Github" => "https://github.com/falood/exsync"}
     }
   end


### PR DESCRIPTION
A hyphen was missing causing the license identifier to not be a valid SPDX license, which resulted in this error message when running `mix hex.publish`:
> The following licenses are not recognized by SPDX:
>  * BSD 3-Clause
> 
> Consider using licenses from https://spdx.org/licenses

@falood I believe this was what you intended in https://github.com/falood/exsync/commit/98f165c831cbad8d95ddc57e271250e25551ae03 but if it wasn't let me know and we can fix the license.