### PR TITLE
Update mix.exs for publishing

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,20 +1,20 @@
 defmodule ExSync.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/falood/exsync"
+  @version "0.3.0"
+
   def project do
     [
       app: :exsync,
-      version: "0.3.0",
+      version: @version,
       elixir: "~> 1.4",
       elixirc_paths: ["lib", "web"],
       deps: deps(),
       description: "Yet another Elixir reloader.",
-      source_url: "https://github.com/falood/exsync",
+      source_url: "https://github.comb/falood/exsync",
       package: package(),
-      docs: [
-        extras: ["README.md"],
-        main: "readme"
-      ]
+      docs: docs()
     ]
   end
 
@@ -38,5 +38,18 @@ defmodule ExSync.Mixfile do
       licenses: ["BSD-3-Clause"],
       links: %{"Github" => "https://github.com/falood/exsync"}
     }
+  end
+
+  defp docs do
+    [
+      extras: [
+        "README.md": [],
+        "CHANGELOG.md": [],
+        LICENSE: [title: "License"]
+      ],
+      main: "readme",
+      source_ref: "v#{@version}",
+      homepage_url: @source_url
+    ]
   end
 end


### PR DESCRIPTION
Publish the changelog and license as part of the docs

This is how the changelog looks like in ex_doc now:
![Screenshot 2023-08-12 08-44-13](https://github.com/falood/exsync/assets/9973/45835232-726b-401c-958d-54478d6eb500)
