### PR TITLE
Add exclusions config option to exclude things like temp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ For example, to watch `.js` and `.css` files add this to your `config.exs`:
 config :exsync, extra_extensions: [".js", ".css"]
 ```
 
+`:exclusions` - List of regular expressions that, if matched, exclude a file from being noticed by exsync.
+
+For example, to exclude Emacs temporary files:
+
+```elixir
+config :exsync, exclusions: [~r/#/]
+```
+
 `:logging_enabled` - Set to false to disable logging (default true)
 
 `:reload_callback` - A callback [MFA](https://codereviewvideos.com/blog/what-is-mfa-in-elixir/) that is called when a set of files are done reloading. Can be used to implement your own special handling to react to file reloads.

--- a/lib/exsync/config.ex
+++ b/lib/exsync/config.ex
@@ -126,6 +126,14 @@ defmodule ExSync.Config do
     )
   end
 
+  def src_exclusions do
+    Application.get_env(
+      :exsync,
+      :exclusions,
+      Application.get_env(:exsync, :exclusions, [])
+    )
+  end
+
   def application do
     :exsync
   end

--- a/lib/exsync/src_monitor.ex
+++ b/lib/exsync/src_monitor.ex
@@ -37,8 +37,14 @@ defmodule ExSync.SrcMonitor do
     # isolation to trigger things.
     matching_event? = :modified in events
 
+    included? =
+      !Enum.any?(
+        ExSync.Config.src_exclusions(),
+        &Regex.match?(&1, path)
+      )
+
     state =
-      if matching_extension? && matching_event? do
+      if matching_extension? && matching_event? && included? do
         maybe_recomplete(state)
       else
         state


### PR DESCRIPTION
Various editors create junk files that wake up exsync, in particular a mix format on save feature in emacs will create a copy of a file for mix format to operate on:
foo_bar.ex => foo_bar-emacs-elixir-format.ex

Seeing this, exsync kicks off the elixir compiler and there is an error about a module being defined in 2 different files.

Being able to exclude files matching `~r/-emacs-elixir-format/` solves this issue.