### PR TITLE
Fix elixir 1.19 compilation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,11 @@ jobs:
       matrix:
         include:
           - elixir: 1.13.1
-            otp: 24.2
+            otp: 24.3.4.17
           - elixir: 1.16.2
             otp: 26.2.5
+          - elixir: 1.19.1
+            otp: 28.1.1
 
     steps:
     - uses: actions/checkout@v4

--- a/lib/exsync/beam_monitor.ex
+++ b/lib/exsync/beam_monitor.ex
@@ -99,7 +99,7 @@ defmodule ExSync.BeamMonitor do
   defp track_module_change(:reload_module, module, state) do
     %State{reload_set: reload_set, unload_set: unload_set} = state
 
-    %State{
+    %{
       state
       | reload_set: MapSet.put(reload_set, module),
         unload_set: MapSet.delete(unload_set, module)
@@ -109,7 +109,7 @@ defmodule ExSync.BeamMonitor do
   defp track_module_change(:unload_module, module, state) do
     %State{reload_set: reload_set, unload_set: unload_set} = state
 
-    %State{
+    %{
       state
       | reload_set: MapSet.delete(reload_set, module),
         unload_set: MapSet.put(unload_set, module)

--- a/lib/exsync/src_monitor.ex
+++ b/lib/exsync/src_monitor.ex
@@ -58,9 +58,9 @@ defmodule ExSync.SrcMonitor do
     {:noreply, state}
   end
 
-  def handle_info(:throttle_timer_complete, state) do
+  def handle_info(:throttle_timer_complete, %State{} = state) do
     ExSync.Utils.recomplete()
-    state = %State{state | throttle_timer: nil}
+    state = %{state | throttle_timer: nil}
     {:noreply, state}
   end
 

--- a/lib/exsync/utils.ex
+++ b/lib/exsync/utils.ex
@@ -13,13 +13,13 @@ defmodule ExSync.Utils do
   end
 
   def unload(beam_path) do
-    beam_path |> Path.basename(".beam") |> String.to_atom() |> unload
+    beam_path |> Path.basename(".beam") |> String.to_atom() |> unload()
   end
 
   # beam file path
   def reload(beam_path) do
     ExSync.Logger.debug("reload module #{Path.basename(beam_path, ".beam")}")
-    file = beam_path |> to_charlist
+    file = beam_path |> to_charlist()
     {:ok, binary, _} = :erl_prim_loader.get_file(file)
     module = beam_path |> Path.basename(".beam") |> String.to_atom()
     :code.load_binary(module, file, binary)


### PR DESCRIPTION
Fixes compilation warnings from using the struct update syntax (which now isn't as necessary because of type inference, although it can still be helpful to make the code more readable)

These were the compilation warnings:
 ```
     warning: a struct for ExSync.SrcMonitor.State is expected on struct update:

        %ExSync.SrcMonitor.State{state | throttle_timer: nil}

    but got type:

        dynamic()

    where "state" was given the type:

        # type: dynamic()
        # from: lib/exsync/src_monitor.ex:61:45
        state

    when defining the variable "state", you must also pattern match on "%ExSync.SrcMonitor.State{}".

    hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

        user = some_function()
        %User{user | name: "John Doe"}

    it is enough to write:

        %User{} = user = some_function()
        %{user | name: "John Doe"}

    typing violation found at:
    │
 63 │     state = %State{state | throttle_timer: nil}
    │             ~
    │
    └─ lib/exsync/src_monitor.ex:63:13: ExSync.SrcMonitor.handle_info/2

     warning: a struct for ExSync.BeamMonitor.State is expected on struct update:

         %ExSync.BeamMonitor.State{
           state
           | reload_set: MapSet.put(reload_set, module),
             unload_set: MapSet.delete(unload_set, module)
         }

     but got type:

         dynamic()

     where "state" was given the type:

         # type: dynamic()
         # from: lib/exsync/beam_monitor.ex:99:52
         state

     when defining the variable "state", you must also pattern match on "%ExSync.BeamMonitor.State{}".

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_function()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_function()
         %{user | name: "John Doe"}

     typing violation found at:
     │
 102 │     %State{
     │     ~
     │
     └─ lib/exsync/beam_monitor.ex:102:5: ExSync.BeamMonitor.track_module_change/3

     warning: a struct for ExSync.BeamMonitor.State is expected on struct update:

         %ExSync.BeamMonitor.State{
           state
           | reload_set: MapSet.delete(reload_set, module),
             unload_set: MapSet.put(unload_set, module)
         }

     but got type:

         dynamic()

     where "state" was given the type:

         # type: dynamic()
         # from: lib/exsync/beam_monitor.ex:109:52
         state

     when defining the variable "state", you must also pattern match on "%ExSync.BeamMonitor.State{}".

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_function()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_function()
         %{user | name: "John Doe"}

     typing violation found at:
     │
 112 │     %State{
     │     ~
     │
     └─ lib/exsync/beam_monitor.ex:112:5: ExSync.BeamMonitor.track_module_change/3
 ```