### PR TITLE
Skip non-existent directories

### DIFF
--- a/lib/exsync/config.ex
+++ b/lib/exsync/config.ex
@@ -37,6 +37,7 @@ defmodule ExSync.Config do
 
           Mix.Project.in_project(app, path, config, fn _ -> beam_dirs() end)
         end)
+        |> Enum.filter(&File.exists?/1)
 
       # Elixir 1.15/OTP 26 compiles into the project build_path, but
       # we append dep_paths to support earlier versions


### PR DESCRIPTION
Fix crash when processing local path dependencies by skipping non-existent nested `_build` directories. 

I think since Elixir v1.15, local dependencies compile artifacts to the parent project's `_build` instead of creating nested build paths, so attempting to  access `pkgs/dep/_build` fails when those directories don't exist.